### PR TITLE
Fixes tests

### DIFF
--- a/t/gambol.lisp
+++ b/t/gambol.lisp
@@ -11,8 +11,8 @@
   (:shadowing-import-from :gambol :is :fail))
 (in-package :gambol-test)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-	(setf (symbol-function 'test-is) (symbol-function 'cl-test-more:is)))
+(defmacro test-is (got expected &rest args)
+  `(cl-test-more:is ,got ,expected ,@args))
 
 (clear-rules)
 (setf *print-circle* nil)


### PR DESCRIPTION
The loading of the tests failed because the value to (setf (symbol function 'test-is)) to was rejected by SBCL. This likely due to a new version of the Prove lib.